### PR TITLE
fixed function to do its job

### DIFF
--- a/cram_gazebo_utilities/src/ros.lisp
+++ b/cram_gazebo_utilities/src/ros.lisp
@@ -60,7 +60,7 @@ gazebo. The pose is given in the `map' frame."
       (with-fields ((name-sequence name)
                     (pose-sequence pose))
           model-state-msg
-        (let ((model-name-index (position name name-sequence :test test)))
+        (let ((model-name-index (position (string-downcase name) name-sequence :test test)))
           (when model-name-index
             (tf:pose->pose-stamped
              "map" 0.0


### PR DESCRIPTION
the function 'position' can't find the the value 'name' in the 'name-sequence' because the values within the sequence are small letters and after extracting the 'name' out of the field, it will be converted into large letters. The function 'string-downcase' is here very necessary.
