### PR TITLE
set correct path for matching/available-process-modules

### DIFF
--- a/gazebo_perception_process_module/src/package.lisp
+++ b/gazebo_perception_process_module/src/package.lisp
@@ -40,7 +40,7 @@
    #:cram-plan-failures)
   (:export #:gazebo-perception-process-module)
   (:shadowing-import-from #:cpl fail)
-  (:import-from #:cram-plan-knowledge
+  (:import-from #:cram-process-modules
                 matching-process-module available-process-module)
   (:desig-properties #:grasp #:cluster #:type #:object #:on #:to #:perceive
                      #:obj #:part-of #:at #:name #:pose #:handle #:lid


### PR DESCRIPTION
package changed: accessing the wrong package
